### PR TITLE
Update parseFeatureFile to skip lines with gherkin comments.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,8 @@
 Cerner Corporation
 - Joshua Kuestersteffen [@jkuester]
 - Matej Voboril [@TobiTenno]
+- Matthew Beers [@beersonthewall]
 
 [@jkuester]: https://github.com/jkuester
 [@TobiTenno]: https://github.com/TobiTenno
+[@beersonthewall]: https://github.com/beersonthewall

--- a/features/generate_report.feature
+++ b/features/generate_report.feature
@@ -20,6 +20,7 @@ Feature: Report Generation
           When I give dog food to the dog
           Then the dog will eat it
 
+        # Do not need examples for left to right and right to left petting directions
         @petting
         Scenario Outline: Petting the Dog
           Dog's do not like to be pet in the wrong direction.
@@ -75,6 +76,7 @@ Feature: Report Generation
     And the report will contain 1 feature
     And the report will contain 2 scenarios
     And the report name on the sidebar will be "All Scenarios"
+    And the report will not contain gherkin comments
     And the project title on the sidebar will be "Feature documentation"
     And the header on the sidebar will be "{username} - {current_date}"
     And the footer on the sidebar will be "Cucumber Forge"

--- a/features/support/generationSteps.js
+++ b/features/support/generationSteps.js
@@ -86,6 +86,15 @@ Then('the report will contain {int} scenario(s)', function (scenarioCount) {
   expect(scenarioDividers.length).to.eql(scenarioCount - featureCount);
 });
 
+Then('the report will not contain gherkin comments', function() {
+    const commentPattern = new RegExp('^#.*');
+    let comments = Array.from(this.outputHTML.getElementsByTagName('*'))
+        .filter(function(obj) {
+            return commentPattern.test(obj.innerHTML);
+        });
+    expect(comments.length).to.eql(0);
+});
+
 Then('the sidebar will contain {int} feature button(s)', function (featureButtonCount) {
   const featureButtons = this.outputHTML.getElementsByClassName('feature-button');
   expect(featureButtons.length).to.eql(featureButtonCount);

--- a/src/Generator.js
+++ b/src/Generator.js
@@ -72,9 +72,6 @@ const getNewPhase = (line) => {
   if (line === '\'\'\'' || line === '"""') {
     return 'DOC_STRING_STARTED';
   }
-  if (line.startsWith('#')){
-      return 'COMMENT_STARTED';
-  } 
   return null;
 };
 
@@ -118,15 +115,14 @@ const parseFeatureFile = async (featureFilename) => {
         case 'EXAMPLES_STARTED':
           scenario.examples = createExamples(line);
           break;
-        case 'COMMENT_STARTED':
-          // Gherkin comments start with '#' and are required to take an entire line.
-          // We want to skip any comment lines.
-          break;
         default:
       }
     } else if (line.startsWith('@')) {
       // Scenario tags
       tags = line.split(' ');
+    } else if (line.startsWith('#')) {
+          // Gherkin comments start with '#' and are required to take an entire line.
+          // We want to skip any comment lines.
     } else if (line.startsWith('|')) {
       const step = scenario.steps[scenario.steps.length - 1];
       const lines = line.split('|').filter(entry => entry).map(entry => entry.trim());

--- a/src/Generator.js
+++ b/src/Generator.js
@@ -72,6 +72,9 @@ const getNewPhase = (line) => {
   if (line === '\'\'\'' || line === '"""') {
     return 'DOC_STRING_STARTED';
   }
+  if (line.startsWith('#')){
+      return 'COMMENT_STARTED';
+  } 
   return null;
 };
 
@@ -114,6 +117,10 @@ const parseFeatureFile = async (featureFilename) => {
           break;
         case 'EXAMPLES_STARTED':
           scenario.examples = createExamples(line);
+          break;
+        case 'COMMENT_STARTED':
+          // Gherkin comments start with '#' and are required to take an entire line.
+          // We want to skip any comment lines.
           break;
         default:
       }


### PR DESCRIPTION
### Summary
Fix for issue #7. Checks for and avoids adding gherkin comments to the final html report. Added a step to validate that no comments are added.