### PR TITLE
Remove Cucumber Keywords from Sidebar Buttons

### DIFF
--- a/features/support/.eslintrc.json
+++ b/features/support/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "func-names": "off",
+    "no-unused-expressions": "off"
+  }
+}

--- a/features/support/generationSteps.js
+++ b/features/support/generationSteps.js
@@ -12,7 +12,6 @@ const FILE_ENCODING = 'utf-8';
 // eslint-disable-next-line no-unused-vars
 const Generator = require('../../src/Generator');
 
-/* eslint-disable func-names */
 Given('there is a file named {string} with the following contents:', function (fileName, contents) {
   const filePath = path.resolve(__dirname, fileName);
   this.featureFiles.push(filePath);
@@ -86,13 +85,11 @@ Then('the report will contain {int} scenario(s)', function (scenarioCount) {
   expect(scenarioDividers.length).to.eql(scenarioCount - featureCount);
 });
 
-Then('the report will not contain gherkin comments', function() {
-    const commentPattern = new RegExp('^#.*');
-    let comments = Array.from(this.outputHTML.getElementsByTagName('*'))
-        .filter(function(obj) {
-            return commentPattern.test(obj.innerHTML);
-        });
-    expect(comments.length).to.eql(0);
+Then('the report will not contain gherkin comments', function () {
+  const commentPattern = new RegExp('^#.*');
+  const comments = Array.from(this.outputHTML.getElementsByTagName('*'))
+    .filter(obj => commentPattern.test(obj.innerHTML));
+  expect(comments.length).to.eql(0);
 });
 
 Then('the sidebar will contain {int} feature button(s)', function (featureButtonCount) {

--- a/features/support/usageSteps.js
+++ b/features/support/usageSteps.js
@@ -6,7 +6,7 @@ const { expect } = require('chai');
 
 const Generator = require('../../src/Generator');
 
-/* eslint-disable func-names */
+/* eslint-disable func-names,no-unused-expressions */
 Given('there is a report for the following feature files:', function (featureFilesTable) {
   const getPath = fileName => path.resolve(__dirname, fileName[0]);
   const filePaths = featureFilesTable.raw().map(getPath);
@@ -58,11 +58,9 @@ Then(/^the (first|second) feature (?:is|will be) displayed$/, function (featureI
   const index = featureIndex === 'first' ? 0 : 1;
   const featureWrappers = this.outputHTML.getElementsByClassName('feature-wrapper');
   const selectedFeatureWrapper = featureWrappers[index];
-  // eslint-disable-next-line no-unused-expressions
   expect(selectedFeatureWrapper.classList.contains('active')).to.be.true;
   Array.from(featureWrappers).forEach((featureWrapper) => {
     if (selectedFeatureWrapper !== featureWrapper) {
-      // eslint-disable-next-line no-unused-expressions
       expect(featureWrapper.classList.contains('active')).to.be.false;
     }
   });
@@ -72,18 +70,21 @@ Then(/^the scenario buttons for the (first|second) feature (?:are|will be) expan
   const index = featureIndex === 'first' ? 0 : 1;
   const featureButtons = this.outputHTML.getElementsByClassName('feature-button');
   const selectedFeatureButton = featureButtons[index];
-  // eslint-disable-next-line no-unused-expressions
   expect(selectedFeatureButton.classList.contains('active')).to.be.true;
   const scenarioPanel = selectedFeatureButton.nextElementSibling;
-  // eslint-disable-next-line no-unused-expressions
   expect(scenarioPanel.style.maxHeight).to.not.be.empty;
+  const selectedIcon = selectedFeatureButton.getElementsByTagName('i')[0];
+  expect(selectedIcon.classList.contains('fa-angle-down')).to.be.true;
+  expect(selectedIcon.classList.contains('fa-angle-right')).to.be.false;
+
   Array.from(featureButtons).forEach((featureButton) => {
     if (selectedFeatureButton !== featureButton) {
-      // eslint-disable-next-line no-unused-expressions
       expect(featureButton.classList.contains('active')).to.be.false;
       const panel = featureButton.nextElementSibling;
-      // eslint-disable-next-line no-unused-expressions
       expect(panel.style.maxHeight).to.be.empty;
+      const icon = featureButton.getElementsByTagName('i')[0];
+      expect(icon.classList.contains('fa-angle-down')).to.be.false;
+      expect(icon.classList.contains('fa-angle-right')).to.be.true;
     }
   });
 });
@@ -91,11 +92,9 @@ Then(/^the scenario buttons for the (first|second) feature (?:are|will be) expan
 Then(/^the (first|second) scenario button will be highlighted$/, function (scenarioIndex) {
   const index = scenarioIndex === 'first' ? 0 : 1;
   const selectedScenarioButton = this.getScenarioButtonByIndex(index);
-  // eslint-disable-next-line no-unused-expressions
   expect(selectedScenarioButton.classList.contains('active')).to.be.true;
   Array.from(this.outputHTML.getElementsByClassName('scenario-button')).forEach((scenarioButton) => {
     if (selectedScenarioButton !== scenarioButton) {
-      // eslint-disable-next-line no-unused-expressions
       expect(scenarioButton.classList.contains('active')).to.be.false;
     }
   });

--- a/features/support/usageSteps.js
+++ b/features/support/usageSteps.js
@@ -6,7 +6,6 @@ const { expect } = require('chai');
 
 const Generator = require('../../src/Generator');
 
-/* eslint-disable func-names,no-unused-expressions */
 Given('there is a report for the following feature files:', function (featureFilesTable) {
   const getPath = fileName => path.resolve(__dirname, fileName[0]);
   const filePaths = featureFilesTable.raw().map(getPath);

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -30,7 +30,6 @@ class CustomWorld {
   }
 }
 
-/* eslint-disable func-names */
 After(function () {
 // Clean up any feature files that got written.
   return this.featureFiles.forEach(filePath => fs.unlinkSync(filePath));

--- a/src/Generator.js
+++ b/src/Generator.js
@@ -121,8 +121,8 @@ const parseFeatureFile = async (featureFilename) => {
       // Scenario tags
       tags = line.split(' ');
     } else if (line.startsWith('#')) {
-          // Gherkin comments start with '#' and are required to take an entire line.
-          // We want to skip any comment lines.
+      // Gherkin comments start with '#' and are required to take an entire line.
+      // We want to skip any comment lines.
     } else if (line.startsWith('|')) {
       const step = scenario.steps[scenario.steps.length - 1];
       const lines = line.split('|').filter(entry => entry).map(entry => entry.trim());

--- a/src/Generator.js
+++ b/src/Generator.js
@@ -196,19 +196,26 @@ const populateHtmlIdentifiers = (features) => {
   });
 };
 
+const trimCucumberKeywords = (name, ...i18nkeys) => {
+  const keywords = i18nkeys.map(i18nkey => i18n.t(i18nkey));
+  const startingKeywords = keywords.filter(key => name.startsWith(key));
+  const charsToTrim = startingKeywords.length > 0 ? startingKeywords[0].length + 1 : 0;
+  return name.slice(charsToTrim).trim();
+};
+
 const getFeatureButtons = (features) => {
   const featureButtons = [];
   features.forEach((feature) => {
     const featureButton = {};
     featureButton.featureId = feature.featureId;
     featureButton.featureWrapperId = feature.featureWrapperId;
-    featureButton.title = feature.name;
+    featureButton.title = trimCucumberKeywords(feature.name, 'feature');
     featureButton.scenarioButtons = [];
     feature.scenarios.forEach((scenario) => {
       const scenarioButton = {};
       scenarioButton.id = scenario.scenarioButtonId;
       scenarioButton.scenarioId = scenario.scenarioId;
-      scenarioButton.title = scenario.name;
+      scenarioButton.title = `- ${trimCucumberKeywords(scenario.name, 'scenario', 'scenario_outline')}`;
       featureButton.scenarioButtons.push(scenarioButton);
     });
     featureButtons.push(featureButton);

--- a/src/Generator.js
+++ b/src/Generator.js
@@ -215,7 +215,7 @@ const getFeatureButtons = (features) => {
       const scenarioButton = {};
       scenarioButton.id = scenario.scenarioButtonId;
       scenarioButton.scenarioId = scenario.scenarioId;
-      scenarioButton.title = `- ${trimCucumberKeywords(scenario.name, 'scenario', 'scenario_outline')}`;
+      scenarioButton.title = trimCucumberKeywords(scenario.name, 'scenario', 'scenario_outline');
       featureButton.scenarioButtons.push(scenarioButton);
     });
     featureButtons.push(featureButton);

--- a/src/templates/doc_template.html
+++ b/src/templates/doc_template.html
@@ -23,7 +23,7 @@
           <div class="panel">
             {{#each this.scenarioButtons}}
               <button id="{{this.id}}" scroll-to-id="{{this.scenarioId}}" class="scenario-button" title="{{this.title}}">
-                <span>{{this.title}}</span>
+                <span>- {{this.title}}</span>
               </button>
             {{/each}}
           </div>

--- a/src/templates/doc_template.html
+++ b/src/templates/doc_template.html
@@ -18,7 +18,7 @@
         </div>
         {{#each featureButtons}}
           <button id="{{this.id}}" scroll-to-id="{{this.featureId}}" feature-wrapper-id="{{this.featureWrapperId}}" class="feature-button" title="{{this.title}}">
-            {{this.title}}
+            <i class="fas fa-angle-right"></i> {{this.title}}
           </button>
           <div class="panel">
             {{#each this.scenarioButtons}}

--- a/src/templates/scripts.js
+++ b/src/templates/scripts.js
@@ -3,9 +3,12 @@ let pauseScrollActions = false;
 
 const toggleFunctionAccordion = (element) => {
   element.classList.toggle('active');
+  const icon = element.getElementsByTagName('i')[0];
   const panel = element.nextElementSibling;
   if (panel.style.maxHeight) {
     panel.style.maxHeight = null;
+    icon.classList.remove('fa-angle-down');
+    icon.classList.add('fa-angle-right');
   } else {
     panel.style.maxHeight = `${panel.scrollHeight}px`;
     // Close all the other panels
@@ -13,8 +16,13 @@ const toggleFunctionAccordion = (element) => {
       if (element !== featureButton) {
         featureButton.classList.remove('active');
         featureButton.nextElementSibling.style.maxHeight = null;
+        const iconToClose = featureButton.getElementsByTagName('i')[0];
+        iconToClose.classList.remove('fa-angle-down');
+        iconToClose.classList.add('fa-angle-right');
       }
     });
+    icon.classList.add('fa-angle-down');
+    icon.classList.remove('fa-angle-right');
   }
 };
 

--- a/src/templates/style.css
+++ b/src/templates/style.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css?family=Lato|Roboto+Mono|Roboto+Slab');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.9.0/css/all.min.css');
 
 html {
   scroll-behavior: smooth;
@@ -91,6 +92,9 @@ table, th, td {
   font-weight: bold;
   color: #404040;
   border-bottom: solid 1px #c9c9c9;
+}
+i.fa-angle-right, i.fa-angle-down { 
+  width: 0.6em; 
 }
 .panel {
   max-height: 0;


### PR DESCRIPTION
Currently the sidebar buttons include Cucumber keywords ("Feature", "Scenario", and "Scenario Outline").  These do not provide a whole lot of value in the sidebar and they waste precious horizontal space.  These changes replace the keywords with single-character pointers that help break up the buttons without taking up so much space.

Example: 
[features.zip](https://github.com/cerner/cucumber-forge-report-generator/files/3437151/features.zip)


closes #5 