### PR TITLE
Automatically regenerate docs when tag is pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ stages:
   - name: test
   - name: publish
     if: branch = master AND type != pull_request
+  - name: docs
 
 jobs:
   include:
@@ -32,3 +33,7 @@ jobs:
       stage: publish
       os: linux
       script: npx semantic-release
+    - name: "Regenerate Documentation"
+      stage: docs
+      os: linux
+      script: node regenerateDocsReport.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ stages:
   - name: publish
     if: branch = master AND type != pull_request
   - name: docs
+    if: branch = master AND type != pull_request
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ jobs:
     - name: "Regenerate Documentation"
       stage: docs
       os: linux
-      script: node regenerateDocsReport.js
+      script: sh ./.travis/deployDocs.sh

--- a/.travis/deployDocs.sh
+++ b/.travis/deployDocs.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+echo Preparing to deploy documentation!
+git config --global user.email "travis@travis-ci.org"
+git config --global user.name "Travis CI"
+git config --global push.default current
+# git stash
+git checkout ${TRAVIS_BRANCH}
+# git stash pop
+
+node regenerateDocsReport.js
+
+git push https://${GH_TOKEN}@github.com/cerner/cucumber-forge-report-generator.git

--- a/.travis/deployDocs.sh
+++ b/.travis/deployDocs.sh
@@ -1,11 +1,8 @@
 #!/bin/sh
-echo Preparing to deploy documentation!
 git config --global user.email "travis@travis-ci.org"
 git config --global user.name "Travis CI"
 git config --global push.default current
-# git stash
 git checkout ${TRAVIS_BRANCH}
-# git stash pop
 
 node ./.travis/regenerateDocsReport.js
 

--- a/.travis/deployDocs.sh
+++ b/.travis/deployDocs.sh
@@ -7,6 +7,6 @@ git config --global push.default current
 git checkout ${TRAVIS_BRANCH}
 # git stash pop
 
-node regenerateDocsReport.js
+node ./.travis/regenerateDocsReport.js
 
 git push https://${GH_TOKEN}@github.com/cerner/cucumber-forge-report-generator.git

--- a/.travis/deployDocs.sh
+++ b/.travis/deployDocs.sh
@@ -6,4 +6,5 @@ git checkout ${TRAVIS_BRANCH}
 
 node ./.travis/regenerateDocsReport.js
 
-git push https://${GH_TOKEN}@github.com/cerner/cucumber-forge-report-generator.git
+git commit ./docs/index.html -m "chore(docs) Regenerate docs"
+git push https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git

--- a/.travis/deployDocs.sh
+++ b/.travis/deployDocs.sh
@@ -1,10 +1,18 @@
 #!/bin/sh
-git config --global user.email "travis@travis-ci.org"
-git config --global user.name "Travis CI"
-git config --global push.default current
 git checkout ${TRAVIS_BRANCH}
 
-node ./.travis/regenerateDocsReport.js
+if [ $(git tag --points-at HEAD) ]
+then
+  echo Regenerating documentation:
 
-git commit ./docs/index.html -m "chore(docs) Regenerate docs"
-git push https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+  node ./.travis/regenerateDocsReport.js
+
+  git config --global user.email "travis@travis-ci.org"
+  git config --global user.name "Travis CI"
+  git config --global push.default current
+  git commit ./docs/index.html -m "chore(docs) Regenerate docs"
+  git push https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+else
+  echo Skipping doc regeneration since no new tag was created.
+fi
+

--- a/.travis/regenerateDocsReport.js
+++ b/.travis/regenerateDocsReport.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const { exec } = require('child_process');
-const Generator = require('./src/Generator');
+const Generator = require('../src/Generator');
 
 const FILE_ENCODING = 'utf-8';
 
@@ -29,26 +29,26 @@ const getFeatureFiles = (directoryName) => {
 };
 
 /* eslint-disable no-console */
-async function sh(cmd) {
-  return new Promise(((resolve, reject) => {
-    exec(cmd, (err, stdout, stderr) => {
-      if (err) {
-        console.error(err);
-        reject(err);
-      } else {
-        console.log(stdout);
-        console.log(stderr);
-        resolve({ stdout, stderr });
-      }
-    });
-  }));
-}
+// async function sh(cmd) {
+//   return new Promise(((resolve, reject) => {
+//     exec(cmd, (err, stdout, stderr) => {
+//       if (err) {
+//         console.error(err);
+//         reject(err);
+//       } else {
+//         console.log(stdout);
+//         console.log(stderr);
+//         resolve({ stdout, stderr });
+//       }
+//     });
+//   }));
+// }
 
 const featureFiles = getFeatureFiles(__dirname);
 new Generator().generate(featureFiles, 'cucumber-forge-report-generator').then((result) => {
   fs.writeFileSync(path.resolve(__dirname, './docs/index.html'), result, FILE_ENCODING);
 });
 
-sh('git commit -a -m "Regenerate docs"').then(() => {
-  sh('git push origin');
-});
+// sh('git commit -a -m "Regenerate docs"').then(() => {
+//   sh('git push origin');
+// });

--- a/.travis/regenerateDocsReport.js
+++ b/.travis/regenerateDocsReport.js
@@ -28,27 +28,7 @@ const getFeatureFiles = (directoryName) => {
   return featureFiles;
 };
 
-/* eslint-disable no-console */
-// async function sh(cmd) {
-//   return new Promise(((resolve, reject) => {
-//     exec(cmd, (err, stdout, stderr) => {
-//       if (err) {
-//         console.error(err);
-//         reject(err);
-//       } else {
-//         console.log(stdout);
-//         console.log(stderr);
-//         resolve({ stdout, stderr });
-//       }
-//     });
-//   }));
-// }
-
 const featureFiles = getFeatureFiles(__dirname);
 new Generator().generate(featureFiles, 'cucumber-forge-report-generator').then((result) => {
   fs.writeFileSync(path.resolve(__dirname, '../docs/index.html'), result, FILE_ENCODING);
 });
-
-// sh('git commit -a -m "Regenerate docs"').then(() => {
-//   sh('git push origin');
-// });

--- a/.travis/regenerateDocsReport.js
+++ b/.travis/regenerateDocsReport.js
@@ -46,7 +46,7 @@ const getFeatureFiles = (directoryName) => {
 
 const featureFiles = getFeatureFiles(__dirname);
 new Generator().generate(featureFiles, 'cucumber-forge-report-generator').then((result) => {
-  fs.writeFileSync(path.resolve(__dirname, './docs/index.html'), result, FILE_ENCODING);
+  fs.writeFileSync(path.resolve(__dirname, '../docs/index.html'), result, FILE_ENCODING);
 });
 
 // sh('git commit -a -m "Regenerate docs"').then(() => {

--- a/regenerateDocsReport.js
+++ b/regenerateDocsReport.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { exec } = require('child_process');
+const Generator = require('./src/Generator');
+
+const FILE_ENCODING = 'utf-8';
+
+const getFeatureFiles = (directoryName) => {
+  if (directoryName.endsWith('node_modules')) {
+    return [];
+  }
+
+  // Recurse on directories:
+  const isDirectory = (source) => fs.lstatSync(source).isDirectory();
+  const getDirectories = (source) => fs
+    .readdirSync(source)
+    .map((name) => path.join(source, name))
+    .filter(isDirectory);
+  const subDirectories = getDirectories(directoryName);
+  const featureFiles = [];
+  subDirectories.forEach((subDirectory) => featureFiles.push(...getFeatureFiles(subDirectory)));
+
+  // Add feature files from this directory.
+  const allFiles = fs.readdirSync(directoryName);
+  const localFeatureFiles = allFiles.filter((item) => item.endsWith('.feature'));
+  localFeatureFiles.forEach((featureFileName) => featureFiles.push(`${directoryName}/${featureFileName}`));
+  return featureFiles;
+};
+
+/* eslint-disable no-console */
+async function sh(cmd) {
+  return new Promise(((resolve, reject) => {
+    exec(cmd, (err, stdout, stderr) => {
+      if (err) {
+        console.error(err);
+        reject(err);
+      } else {
+        console.log(stdout);
+        console.log(stderr);
+        resolve({ stdout, stderr });
+      }
+    });
+  }));
+}
+
+const featureFiles = getFeatureFiles(__dirname);
+new Generator().generate(featureFiles, 'cucumber-forge-report-generator').then((result) => {
+  fs.writeFileSync(path.resolve(__dirname, './docs/index.html'), result, FILE_ENCODING);
+});
+
+sh('git commit -a -m "Regenerate docs"').then(() => {
+  sh('git push origin');
+});


### PR DESCRIPTION
Adds a stage to the Travis build to regenerate the Cucumber feature report used as the docs index.html.  

The report will only be regenerated during master branch builds when the semantic-release plugin has already tagged a version.

Closes #11 