### PR TITLE
fix(Generator): prevent crashing when features are filtered out by tag

### DIFF
--- a/features/generate_report.feature
+++ b/features/generate_report.feature
@@ -101,7 +101,7 @@ Feature: Report Generation
     Then the title on the report will be "Pet Project - {current_date}"
     And the project title on the sidebar will be "Pet Project"
 
-  Scenario Outline: Generating an HTML report filtered by a tag
+  Scenario Outline: Generating an HTML report with scenarios filtered by a tag
     The features and scenarios included in a report can be filtered based on their tags.
     The provided tag can optionally be prefixed with '@'.
 
@@ -116,6 +116,16 @@ Feature: Report Generation
       | tag:       |
       | 'feeding'  |
       | '@feeding' |
+
+  Scenario: Generating an HTML report with features filtered by a tag
+    The features and scenarios included in a report can be filtered based on their tags.
+
+    When a report is generated with the code "new Generator().generate(this.allFeaturesPath, null, '@cats')"
+    Then the report will contain 1 feature
+    And the report will contain 2 scenarios
+    And the report name on the sidebar will be '@cats'
+    And the sidebar will contain 1 feature button
+    And the sidebar will contain 2 scenario buttons
 
   @exception
   Scenario: Generating a report when no path is provided

--- a/src/Generator.js
+++ b/src/Generator.js
@@ -190,19 +190,18 @@ const populateTagStrings = (feature) => {
   });
 };
 
+const includeFeature = (feature) => {
+  if (!tagFilter || feature.tags.includes(tagFilter)) {
+    return true;
+  }
+  feature.scenarios = getFilteredScenarios(feature.scenarios);
+  return feature.scenarios.length > 0;
+};
+
 // eslint-disable-next-line no-unused-vars
 const parseFeatureFile = (item, nodePath, fsStats) => {
-  let feature = getFeatureFromFile(item.path);
-
-  if (tagFilter) {
-    const filteredScenarios = getFilteredScenarios(feature.scenarios);
-    if (filteredScenarios.length > 0) {
-      feature.scenarios = filteredScenarios;
-    } else {
-      feature = undefined;
-    }
-  }
-  if (feature) {
+  const feature = getFeatureFromFile(item.path);
+  if (includeFeature(feature)) {
     item.feature = feature;
     populateHtmlIdentifiers(feature);
     populateTagStrings(feature);
@@ -211,7 +210,7 @@ const parseFeatureFile = (item, nodePath, fsStats) => {
 
 const pruneFeatureFileTree = (featureFileTree) => {
   featureFileTree.children = featureFileTree.children
-    .filter((child) => child.type === 'file' || pruneFeatureFileTree(child));
+    .filter((child) => (child.type === 'file' ? child.feature : pruneFeatureFileTree(child)));
   return featureFileTree.children.length > 0;
 };
 


### PR DESCRIPTION
- Update the generation code to successfully filter feature files out of the report (when filtering by tag).
- Support filtering by feature-level tags.

Closes #44, #38 
