### PR TITLE
fix: ignore types & script folders

### DIFF
--- a/tsconfig.declaration.json
+++ b/tsconfig.declaration.json
@@ -4,7 +4,10 @@
   ],
   "exclude": [
     "features/**/*.*",
-    "docs/**/*.*"
+    "docs/**/*.*",
+    "types/**/*.*",
+    ".travis/**/*.*",
+    ".github/**/*.*"
   ],
   "compilerOptions": {
     "outDir": "./types",


### PR DESCRIPTION
### Summary
Ignore the types output folders and script folders so the run doesn't try to read types as an input folder