### PR TITLE
feat(Generator): support simple regex for tags

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
-Please fill out the below template as best you can.
---------------------------------------------------------
+<!-- Please fill out the below template as best you can.
+-------------------------------------------------------->
 
 ### Description of Issue
-Describe the issue as best you can. Screenshots, logs, and stack traces can be very helpful!
+<!-- Describe the issue as best you can. Screenshots, logs, and stack traces can be very helpful! -->
 
 ### System Configuration
 #### Project Version
@@ -14,5 +14,7 @@ Describe the issue as best you can. Screenshots, logs, and stack traces can be v
 1. Step 2
 
 ### Expected Outcomes
+<!--
 - Links can be styled as buttons
 - Disabled links behave the same as disabled buttons
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,15 @@
 ### Summary
-Summarize the contents of the code changes in your pull request. Tag any open issues you believe to be resolved by this pull request.
+<!-- Summarize the contents of the code changes in your pull request. Tag any open issues you believe to be resolved by this pull request. -->
 
 ### Additional Details
+<!-- 
 If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process.
 
 Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].
 
-Thanks for contributing to cucumber-forge-report-generator. 
+Thanks for contributing to cucumber-forge-report-generator.
 
 [CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
 [License]: ../blob/main/LICENSE
+
+-->

--- a/features/generate_report.feature
+++ b/features/generate_report.feature
@@ -17,7 +17,7 @@ Feature: Report Generation
 
         @feeding
         Scenario: Feeding the Dog
-          Given the dog is hungery
+          Given the dog is hungry
           When I give dog food to the dog
           Then the dog will eat it
 
@@ -47,7 +47,7 @@ Feature: Report Generation
 
         @feeding
         Scenario: Feeding the Cat
-          Given the cat is hungery
+          Given the cat is hungry
           When I give the following food to the cat:
             | fish  |
             | steak |
@@ -116,6 +116,10 @@ Feature: Report Generation
       | tag:       |
       | 'feeding'  |
       | '@feeding' |
+      | '@feed*'   |
+      | '@feeding*'|
+      | 'feed*'    |
+      | 'feeding*' |
 
   Scenario: Generating an HTML report with features filtered by a tag
     The features and scenarios included in a report can be filtered based on their tags.
@@ -142,7 +146,7 @@ Feature: Report Generation
 
         @feeding
         Scenario: Feeding the Dog
-          Given the dog is hungery
+          Given the dog is hungry
           When I give dog food to the dog
           Then the dog will eat it
       """
@@ -153,7 +157,7 @@ Feature: Report Generation
     Given there is a file named 'invalid.feature' in the 'feature/dog' directory with the following contents:
       """
       Feature: Dog Care
-          Given the dog is hungery
+          Given the dog is hungry
           When I give dog food to the dog
           Then the dog will eat it
       """
@@ -163,7 +167,7 @@ Feature: Report Generation
   Scenario: Generating a report when the directory contains a feature file that has only Cucumber steps
     Given there is a file named 'invalid.feature' in the 'feature/dog' directory with the following contents:
       """
-          Given the dog is hungery
+          Given the dog is hungry
           When I give dog food to the dog
           Then the dog will eat it
       """
@@ -264,7 +268,7 @@ Feature: Report Generation
       # language: american
       Feature: Dog Care
         Scenario: Feeding the Dog
-          Given the dog is hungery
+          Given the dog is hungry
           When I give dog food to the dog
           Then the dog will eat it
       """

--- a/package-lock.json
+++ b/package-lock.json
@@ -2846,6 +2846,12 @@
       "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
       "dev": true
     },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "src/Generator.js",
   "types": "types/Generator.d.ts",
   "scripts": {
-    "test": "./node_modules/.bin/cucumber-js features/*.feature",
-    "lint": "npx eslint src --color",
-    "build:types": "npx -p typescript tsc -p tsconfig.declaration.json",
+    "test": "cucumber-js features/*.feature",
+    "lint": "eslint src --color",
+    "build:types": "tsc -p tsconfig.declaration.json",
     "prepublishOnly": "npm run build:types"
   },
   "repository": {
@@ -24,7 +24,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "release": {
-    "branches": ["main"],
+    "branches": [
+      "main"
+    ],
     "repositoryUrl": "https://github.com/cerner/cucumber-forge-report-generator.git"
   },
   "dependencies": {
@@ -41,6 +43,7 @@
     "eslint": "^7.9.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.22.0",
-    "jsdom": "^16.4.0"
+    "jsdom": "^16.4.0",
+    "typescript": "^4.1.3"
   }
 }

--- a/src/Generator.js
+++ b/src/Generator.js
@@ -186,12 +186,24 @@ const getFeatureFromFile = (featureFilename) => {
   return feature;
 };
 
-const getFilteredScenarios = (scenarios) => scenarios.map((scenario) => {
-  if (scenario.tags && scenario.tags.includes(tagFilter)) {
-    return scenario;
+const filter = (scenario, tagFilter) => {
+  // empty filter: allow all
+  if (!tagFilter) return true;
+
+  let allow = false;
+  const wild = tagFilter.endsWith('*');
+  const strippedFilter = tagFilter.endsWith('*') ? tagFilter.slice(0, -1) : tagFilter;
+  if (scenario.tags) {
+    scenario.tags.forEach((tag) => {
+      if ((wild && tag.startsWith(strippedFilter)) ||  tag === strippedFilter) {
+        allow = true;
+      }
+    });
   }
-  return undefined;
-}).filter((scenario) => scenario);
+  return allow;
+}
+
+const getFilteredScenarios = (scenarios) => scenarios.filter(scenario => filter(scenario, tagFilter));
 
 const populateHtmlIdentifiers = (feature) => {
   feature.featureId = idSequence;


### PR DESCRIPTION
### Summary
closes #65 
Support filtering with simple ending wildcards

### Additional Details
- cleaned up scripts to use dev dependencies instead of npx or any bin entries
- cleaned up issue & pr templates to have less boilerplate text that could accidentally be left in